### PR TITLE
Global variable wrong position

### DIFF
--- a/Inheritance.py
+++ b/Inheritance.py
@@ -6,21 +6,18 @@ class Vehicle():
         self._max_speed = max_speed
 
 class Car(Vehicle):
-    CAR_WHEELS = 4
-
     def __init__(self, num_seats, max_speed):
+        CAR_WHEELS = 4
         Vehicle.__init__(self, num_seats, CAR_WHEELS, max_speed)
 
 class SportsCar(Car):
-    SPORTS_CAR_SEATS = 2
-    SPORTS_CAR_MAX_SPEED = 300
-
     def __init__(self, max_speed):
+        SPORTS_CAR_SEATS = 2
+        SPORTS_CAR_MAX_SPEED = 300
         Car.__init__(self, SPORTS_CAR_SEATS, SPORTS_CAR_MAX_SPEED)
 
 class Bicycle(Vehicle):
-    BICYCLE_RIDERS = 1
-    BICYCLE_WHEELS = 2
-
     def __init__(self, max_speed):
+        BICYCLE_RIDERS = 1
+        BICYCLE_WHEELS = 2
         Vehicle.__init__(self, BICYCLE_RIDERS, BICYCLE_WHEELS, max_speed)


### PR DESCRIPTION
The global variable should be inside the __init__ method in order for Python to find it.
Alternatively, we can use ClassName.CONSTANT, e.g. Car.CAR_WHEELS